### PR TITLE
Provide stable identifier when updating indexes

### DIFF
--- a/src/django_ai_core/contrib/index/source.py
+++ b/src/django_ai_core/contrib/index/source.py
@@ -237,9 +237,10 @@ class ModelSource(ObjectSource):
     def post_index_update(self, index):
         from .models import ModelSourceIndex
 
+        index_name = type(index).__name__
         ModelSourceIndex.objects.filter(
-            index_name=index, source_id=self.source_id
+            index_name=index_name, source_id=self.source_id
         ).delete()
 
         for obj in self.queryset:
-            ModelSourceIndex.register(obj, index, self.source_id)
+            ModelSourceIndex.register(obj, index_name, self.source_id)

--- a/tests/unit/contrib/index/test_model_source.py
+++ b/tests/unit/contrib/index/test_model_source.py
@@ -1,4 +1,5 @@
 import random
+import uuid
 
 import pytest
 from testapp.models import Book
@@ -70,8 +71,11 @@ def test_model_source_returns_unique_keys():
 @pytest.mark.django_db
 def test_model_source_registers_index_by_class_name():
     class VerboseIndex:
+        def __init__(self):
+            self._unique_id = uuid.uuid4()
+
         def __repr__(self):
-            return "verbose index representation" * 100
+            return f"verbose index representation {self._unique_id} " * 100
 
     Book.objects.create(title="Book Title", description="Description")
 

--- a/tests/unit/contrib/index/test_model_source.py
+++ b/tests/unit/contrib/index/test_model_source.py
@@ -3,6 +3,7 @@ import random
 import pytest
 from testapp.models import Book
 
+from django_ai_core.contrib.index.models import ModelSourceIndex
 from django_ai_core.contrib.index.source import ModelSource
 
 
@@ -64,3 +65,20 @@ def test_model_source_returns_unique_keys():
     documents = model_source.get_documents()
     document_keys = [doc.document_key for doc in documents]
     assert len(document_keys) == len(set(document_keys))
+
+
+@pytest.mark.django_db
+def test_model_source_registers_index_by_class_name():
+    class VerboseIndex:
+        def __repr__(self):
+            return "verbose index representation" * 100
+
+    Book.objects.create(title="Book Title", description="Description")
+
+    source = ModelSource(model=Book)
+    source.post_index_update(VerboseIndex())
+    source.post_index_update(VerboseIndex())
+
+    registration = ModelSourceIndex.objects.get()
+    assert ModelSourceIndex.objects.count() == 1
+    assert registration.index_name == "VerboseIndex"


### PR DESCRIPTION
Fixes #15

### Description

Uses the index class name when registering indexes to prevent accumulation of `__repr__` based index names.


### AI usage

AI wrote the test for this fix.