### PR TITLE
Prune removed documents after index update

### DIFF
--- a/src/django_ai_core/contrib/index/base.py
+++ b/src/django_ai_core/contrib/index/base.py
@@ -49,6 +49,7 @@ class VectorIndex:
         1. Get documents from all sources
         2. Process them through the embedding pipeline
         3. Store the embedded documents in the vector storage
+        4. Remove stored documents that are no longer supplied by a source
 
         Returns:
             Self for method chaining
@@ -58,11 +59,10 @@ class VectorIndex:
             logger.info(f"Getting documents from source {source.source_id}")
             documents.extend(source.get_documents())
 
-        if not documents:
-            logger.warning("No documents provided by sources")
-            return self
-
         self.update(documents)
+
+        logger.info("Removing stale documents from vector storage")
+        self.storage_provider.prune_to(document.document_key for document in documents)
 
         return self
 

--- a/src/django_ai_core/contrib/index/storage/base.py
+++ b/src/django_ai_core/contrib/index/storage/base.py
@@ -94,6 +94,11 @@ class StorageProvider(ABC):
         """Clear the vector database."""
         ...
 
+    @abstractmethod
+    def prune_to(self, document_keys_to_keep: Iterable[str]):
+        """Remove stored documents whose keys are not in the supplied keep-set."""
+        ...
+
     @property
     def objects(self):
         return self.document_cls().objects

--- a/src/django_ai_core/contrib/index/storage/inmemory.py
+++ b/src/django_ai_core/contrib/index/storage/inmemory.py
@@ -56,3 +56,9 @@ class InMemoryProvider(StorageProvider):
     def clear(self):
         """Clear the vector database."""
         self.documents.clear()
+
+    def prune_to(self, document_keys_to_keep):
+        """Remove documents that are not part of the rebuilt index."""
+        document_keys_to_keep = set(document_keys_to_keep)
+        for key in set(self.documents) - document_keys_to_keep:
+            del self.documents[key]

--- a/src/django_ai_core/contrib/index/storage/llamaindex.py
+++ b/src/django_ai_core/contrib/index/storage/llamaindex.py
@@ -100,3 +100,18 @@ class LlamaIndexProvider(StorageProvider):
     def clear(self):
         """Clear the vector database."""
         self.vector_store.clear()
+
+    def prune_to(self, document_keys_to_keep):
+        """Remove documents that are not part of the rebuilt index."""
+        document_keys_to_keep = set(document_keys_to_keep)
+
+        # SimpleVectorStore, the default store, exposes its node IDs through
+        # ``data``. Other LlamaIndex stores may expose them via get_nodes().
+        if hasattr(self.vector_store, "data"):
+            stored_keys = self.vector_store.data.embedding_dict.keys()
+        else:
+            stored_keys = (node.node_id for node in self.vector_store.get_nodes())
+
+        stale_keys = list(set(stored_keys) - document_keys_to_keep)
+        if stale_keys:
+            self.vector_store.delete_nodes(stale_keys)

--- a/src/django_ai_core/contrib/index/storage/pgvector/provider.py
+++ b/src/django_ai_core/contrib/index/storage/pgvector/provider.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Generator, Type, cast
+from typing import TYPE_CHECKING, Generator, Iterable, Type, cast
 
 from ...schema import EmbeddedDocument
 from ..base import BaseStorageDocument, BaseStorageQuerySet, StorageProvider
@@ -144,8 +144,16 @@ class PgVectorProvider(StorageProvider):
         Args:
             document_keys: List of document keys to delete.
         """
-        self.model.objects.filter(document_key__in=document_keys).delete()
+        self.model.objects.filter(
+            index_name=self.index_name, document_key__in=document_keys
+        ).delete()
 
     def clear(self) -> None:
-        """Clear all documents from the database."""
-        self.model.objects.all().delete()
+        """Clear documents belonging to this index from the database."""
+        self.model.objects.filter(index_name=self.index_name).delete()
+
+    def prune_to(self, document_keys_to_keep: Iterable[str]) -> None:
+        """Remove documents that are not part of the rebuilt index."""
+        self.model.objects.filter(index_name=self.index_name).exclude(
+            document_key__in=document_keys_to_keep
+        ).delete()

--- a/src/django_ai_core/contrib/index/storage/qdrant.py
+++ b/src/django_ai_core/contrib/index/storage/qdrant.py
@@ -127,3 +127,26 @@ class QdrantProvider(StorageProvider):
     def clear(self):
         """Clear the vector database."""
         self.client.delete_collection(collection_name=self.index_name)
+
+    def prune_to(self, document_keys_to_keep):
+        """Remove documents that are not part of the rebuilt index."""
+        document_keys_to_keep = list(document_keys_to_keep)
+        if not self.client.collection_exists(self.index_name):
+            return
+        if not document_keys_to_keep:
+            self.clear()
+            return
+
+        self.client.delete(
+            collection_name=self.index_name,
+            points_selector=qdrant_models.FilterSelector(
+                filter=qdrant_models.Filter(
+                    must_not=[
+                        qdrant_models.FieldCondition(
+                            key="document_key",
+                            match=qdrant_models.MatchAny(any=document_keys_to_keep),
+                        )
+                    ]
+                )
+            ),
+        )

--- a/src/django_ai_core/contrib/index/storage/s3vectors.py
+++ b/src/django_ai_core/contrib/index/storage/s3vectors.py
@@ -138,3 +138,29 @@ class S3VectorProvider(StorageProvider):
         self.client.delete_index(
             vectorBucketName=self.bucket_name, indexName=self.index_name
         )
+
+    def prune_to(self, document_keys_to_keep):
+        """Remove documents that are not part of the rebuilt index."""
+        document_keys_to_keep = set(document_keys_to_keep)
+        next_token = None
+
+        while True:
+            params = {
+                "vectorBucketName": self.bucket_name,
+                "indexName": self.index_name,
+            }
+            if next_token:
+                params["nextToken"] = next_token
+            response = self.client.list_vectors(**params)
+
+            stale_keys = [
+                key
+                for key in response["vectorKeys"]
+                if key not in document_keys_to_keep
+            ]
+            if stale_keys:
+                self.delete(stale_keys)
+
+            next_token = response.get("nextToken")
+            if not next_token:
+                break

--- a/tests/integration/pgvector/test_pgvector_provider.py
+++ b/tests/integration/pgvector/test_pgvector_provider.py
@@ -87,7 +87,7 @@ class TestPgVectorProvider:
         assert PgVectorEmbedding.objects.filter(pk="test:1").count() == 0
 
     def test_clear(self, pg_vector_provider):
-        """Test clearing all documents."""
+        """Test clearing all documents for the provider's index."""
         docs = [
             create_embedded_document(key="test:1"),
             create_embedded_document(key="test:2"),
@@ -95,6 +95,30 @@ class TestPgVectorProvider:
         pg_vector_provider.add(docs)
         pg_vector_provider.clear()
         assert PgVectorEmbedding.objects.count() == 0
+
+    def test_prune_documents_not_in_rebuild(self, pg_vector_provider):
+        pg_vector_provider.add(
+            [
+                create_embedded_document(key="test:current"),
+                create_embedded_document(key="test:stale"),
+            ]
+        )
+
+        pg_vector_provider.prune_to(["test:current"])
+
+        assert PgVectorEmbedding.objects.filter(pk="test:current").exists()
+        assert not PgVectorEmbedding.objects.filter(pk="test:stale").exists()
+
+    def test_clear_does_not_remove_documents_from_other_indexes(self):
+        first_provider = PgVectorProvider(index_name="first-index")
+        second_provider = PgVectorProvider(index_name="second-index")
+        first_provider.add([create_embedded_document(key="first:1")])
+        second_provider.add([create_embedded_document(key="second:1")])
+
+        first_provider.clear()
+
+        assert not PgVectorEmbedding.objects.filter(index_name="first-index").exists()
+        assert PgVectorEmbedding.objects.filter(index_name="second-index").exists()
 
     def test_queryset_run_query(self, pg_vector_provider):
         """Test that PgVectorQuerySet.run_query works correctly."""

--- a/tests/unit/contrib/index/test_query_handler.py
+++ b/tests/unit/contrib/index/test_query_handler.py
@@ -126,6 +126,9 @@ class MockStorageProvider(StorageProvider):
     def clear(self):
         pass
 
+    def prune_to(self, document_keys_to_keep):
+        pass
+
 
 class TestDocumentResultMixin:
     def test_returns_raw_documents(self):

--- a/tests/unit/contrib/index/test_storage.py
+++ b/tests/unit/contrib/index/test_storage.py
@@ -65,6 +65,19 @@ class TestInMemoryProvider:
         provider.clear()
         assert len(provider.documents) == 0
 
+    def test_prune_documents_not_in_rebuild(self):
+        provider = InMemoryProvider()
+        provider.add(
+            [
+                create_embedded_document(key="test:current"),
+                create_embedded_document(key="test:stale"),
+            ]
+        )
+
+        provider.prune_to(["test:current"])
+
+        assert list(provider.documents) == ["test:current"]
+
     def test_document_class_generation(self):
         """Test document_cls property generates correct class."""
         provider = InMemoryProvider()

--- a/tests/unit/contrib/index/test_vector_index.py
+++ b/tests/unit/contrib/index/test_vector_index.py
@@ -14,6 +14,7 @@ class MockStorageProvider(StorageProvider):
         self.added_documents = []
         self.cleared = False
         self.deleted_keys = []
+        self.pruned_document_keys = []
         self.base_queryset_cls = mock.MagicMock()
 
     def add(self, documents):
@@ -25,6 +26,14 @@ class MockStorageProvider(StorageProvider):
     def clear(self):
         self.cleared = True
         self.added_documents = []
+
+    def prune_to(self, document_keys_to_keep):
+        self.pruned_document_keys = list(document_keys_to_keep)
+        self.added_documents = [
+            document
+            for document in self.added_documents
+            if document.document_key in self.pruned_document_keys
+        ]
 
 
 class MockEmbeddingTransformer(EmbeddingTransformer):
@@ -90,6 +99,7 @@ def test_vector_index_build_empty():
     result = index.build()
 
     assert result == index
+    assert index.storage_provider.pruned_document_keys == []
     assert len(index.storage_provider.added_documents) == 0
 
 
@@ -113,6 +123,36 @@ def test_vector_index_build_with_documents():
     assert len(index.storage_provider.added_documents) == 2
     assert index.storage_provider.added_documents[0].document_key == "mock-source:1"
     assert index.storage_provider.added_documents[1].document_key == "mock-source:2"
+
+
+def test_vector_index_build_removes_stale_documents():
+    source = MockSource(
+        [
+            Document(
+                document_key="mock-source:current",
+                content="Current document",
+                metadata={"id": 1},
+            )
+        ]
+    )
+    index = create_test_vector_index_cls(sources=[source])()
+
+    # Simulate a document that was present during a previous build but is no
+    # longer returned by the source (for example, it was unpublished).
+    index.storage_provider.added_documents.append(
+        Document(
+            document_key="mock-source:stale",
+            content="Stale document",
+            metadata={"id": 2},
+        )
+    )
+
+    index.build()
+
+    assert not index.storage_provider.cleared
+    assert [
+        document.document_key for document in index.storage_provider.added_documents
+    ] == ["mock-source:current"]
 
 
 def test_vector_index_update():


### PR DESCRIPTION
<!-- Insert the issue number that you're fixing here, if any -->
Fixes #13 

### Description

When indexes are rebuilt, old documents that are no longer in the source data aren't correctly removed.
This adds a `prune_to` method on storage providers that finds keys that aren't in the provided set and removes them.


### AI usage

AI (GPT 5.6) was used to author this change with human review and guidance.
